### PR TITLE
Fix start command

### DIFF
--- a/examples/next/default-app-dir-standalone/dockerfile
+++ b/examples/next/default-app-dir-standalone/dockerfile
@@ -20,5 +20,4 @@ RUN bun run build
 EXPOSE 3000
 
 # Start the app
-CMD ["node", "run", "start"]
-
+CMD ["bun", "run", "start"]


### PR DESCRIPTION
When referencing your example I noticed the start command was incorrect so I updated it 

`node run start` results in error 
Solution: `bun run start`