### PR TITLE
fix(build): pass BUN_VERSION build-arg (canary tags were built from latest)

### DIFF
--- a/build_updated.sh
+++ b/build_updated.sh
@@ -140,13 +140,21 @@ for bun_version in "${BUN_VERSIONS[@]}"; do
       log "Building image for Bun version $bun_version, Node version $node_version, Distro $distro"
       image_name="$REGISTRY/bun-node:${bun_version}-${node_version}-${tag_distro}"
 
+      # Pass the exact Bun version as a build arg. Canary versions map to the
+      # floating "canary" GitHub release tag (pinned canary releases are not
+      # published on GitHub), everything else to "bun-v<version>".
+      bun_build_arg="$bun_version"
+      if [[ $bun_version == *"-canary"* ]]; then
+        bun_build_arg="canary"
+      fi
+
       for tag in "${tags[@]}"; do
         log "Tagging $image_name as $tag"
-        retry docker buildx build --sbom=true --provenance=true --platform "$PLATFORMS" -t "$image_name" -t "$tag" "./src/base/${node_major}/${distro}" --push --provenance=mode=max
+        retry docker buildx build --sbom=true --provenance=true --platform "$PLATFORMS" -t "$image_name" -t "$tag" --build-arg BUN_VERSION="$bun_build_arg" "./src/base/${node_major}/${distro}" --push --provenance=mode=max
 
         if [ "$distro" == "alpine" ]; then
           log "Building and Tagging Alpine image with Git"
-          retry docker buildx build --sbom=true --provenance=true --platform "$PLATFORMS" -t "$image_name-git" -t "$tag-git" "./src/git/${node_major}/${distro}" --push --provenance=mode=max
+          retry docker buildx build --sbom=true --provenance=true --platform "$PLATFORMS" -t "$image_name-git" -t "$tag-git" --build-arg BUN_VERSION="$bun_build_arg" "./src/git/${node_major}/${distro}" --push --provenance=mode=max
         fi
       done
 


### PR DESCRIPTION
**Bug:** `build_updated.sh` never passes `--build-arg BUN_VERSION`, so the Dockerfile's `ARG BUN_VERSION=latest` default is used for every build. All `canary-*` tags (e.g. `canary-24.19.0-slim`) are therefore identical to `latest-*` images — bun 1.3.14 — instead of the canary channel.

**Fix:** pass `--build-arg BUN_VERSION=$bun_version`. Canary versions (containing `-canary`) map to the floating `canary` GitHub release tag, since pinned canary releases (e.g. `bun-v1.3.13-canary.20260425.1`) are not published on GitHub (404).

Verified: `https://github.com/oven-sh/bun/releases/download/canary/bun-linux-x64-baseline.zip` → 206 (exists); pinned canary URL → 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image builds to use the correct Bun version for both canary and stable releases.
  * Ensured version information is consistently passed to base and Alpine Git images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->